### PR TITLE
Remove the use of !important

### DIFF
--- a/src/components/molecules/Dropdown.js
+++ b/src/components/molecules/Dropdown.js
@@ -2,8 +2,10 @@ import React from "react";
 import styled from "styled-components";
 
 const Drop = styled("select")`
-    width: 100%;
-    height: 25px !important;
+	&&&& {
+		width: 100%;
+		height: 25px;
+    }
 `;
 
 function Dropdown({ label, value, onChangeHandler, children }) {

--- a/src/components/molecules/Navigation.js
+++ b/src/components/molecules/Navigation.js
@@ -9,8 +9,10 @@ const NavList = styled("ul")`
 `;
 
 const ImgLogo = styled("img")`
-    height: 50px;
-    padding: 20px !important;
+	&& {
+		height: 50px;
+		padding: 20px;
+    }
 `;
 
 function Navigation() {

--- a/src/components/molecules/SearchBar.js
+++ b/src/components/molecules/SearchBar.js
@@ -2,8 +2,10 @@ import React from "react";
 import styled from "styled-components";
 
 const Search = styled("input")`
-    width: 100%;
-    height: 25px !important;
+	&& {
+		width: 100%;
+		height: 25px;
+    }
 `;
 
 function SearchBar({ label, onChangeHandler }) {


### PR DESCRIPTION
# !important
## Summary
This PR removes the use of `!important` for the `Dropdown`, `SearchBar` and `Navigation` components and instead favours the use of `&` which is the generated class name.

Docs: https://styled-components.com/docs/faqs#how-can-i-override-styles-with-higher-specificity