### PR TITLE
Only enable credentials flag for local development

### DIFF
--- a/src/pages/_app.js
+++ b/src/pages/_app.js
@@ -5,7 +5,9 @@ import "../../node_modules/uikit/dist/css/uikit.min.css";
 import "../styles/hljs-theme.css";
 import "../styles/style.css";
 
-axios.defaults.withCredentials = true;
+if (typeof window !== "undefined") {
+	axios.defaults.withCredentials = location.hostname === "localhost";
+}
 
 function App({ Component, pageProps }) {
 	return (


### PR DESCRIPTION
# CORS
## Summary
This PR changes the `axios.defaults.withCredentials` flag to only ever be enabled for local development.