### PR TITLE
Syntax highlighting

### DIFF
--- a/src/components/atoms/Markdown.js
+++ b/src/components/atoms/Markdown.js
@@ -1,7 +1,7 @@
 import React from "react";
 import ReactMarkdown from "react-markdown";
-import SyntaxHighlighter from "react-syntax-highlighter";
-import { materialDark } from "react-syntax-highlighter/dist/cjs/styles/prism";
+import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
+import { darcula } from "react-syntax-highlighter/dist/cjs/styles/prism";
 
 function CodeBlock({ language, value }) {
 	if (!value) return null;
@@ -9,7 +9,7 @@ function CodeBlock({ language, value }) {
 	return (
 		<SyntaxHighlighter
 			language={language}
-			style={materialDark}
+			style={darcula}
 		>
 			{value}
 		</SyntaxHighlighter>


### PR DESCRIPTION
# Article syntax highlighting
## Summary
This PR changes the syntax highlighting module to use the Darcula theme provided by Prism. It also changes the SyntaxHighlighter import as previously the one being imported was for HLJS and not Prism.

### Screenshots
#### Previous
<img width="1440" alt="Screenshot 2021-03-20 at 01 01 14" src="https://user-images.githubusercontent.com/20248039/111855447-f5bfa800-891c-11eb-9c49-4299b50789c3.png">

#### Updated
<img width="1440" alt="Screenshot 2021-03-20 at 01 01 30" src="https://user-images.githubusercontent.com/20248039/111855455-0112d380-891d-11eb-81a2-b98b5ae041c2.png">

#### Article example
<img width="732" alt="Screenshot 2021-03-20 at 01 14 56" src="https://user-images.githubusercontent.com/20248039/111855501-125be000-891d-11eb-9389-1ee69d97949b.png">
 