### PR TITLE
Exclude Sitemap Soft URLs

### DIFF
--- a/.github/scripts/generate-sitemap.js
+++ b/.github/scripts/generate-sitemap.js
@@ -4,6 +4,7 @@ sitemap({
 	baseUrl: "https://codesupport.dev",
 	pagesDirectory: "out/",
 	targetDirectory: "out/",
+	ignoredPaths: ["404", "article/[path]"],
 	ignoredExtensions: [
 		"png",
 		"ico"

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "eslint-config-codesupport": "^1.0.2",
         "eslint-plugin-react": "^7.20.3",
         "jest": "^26.6.3",
-        "nextjs-sitemap-generator": "^1.1.1"
+        "nextjs-sitemap-generator": "^1.3.1"
       }
     },
     "node_modules/@ampproject/toolbox-core": {
@@ -10686,9 +10686,9 @@
       "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
     },
     "node_modules/nextjs-sitemap-generator": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/nextjs-sitemap-generator/-/nextjs-sitemap-generator-1.1.3.tgz",
-      "integrity": "sha512-CNZ9pN4FNsXvkhtU7o2yPkyxEIsjwWJxGNLTDYApRJhdtZ0FfZzPleRHFCJPdbtiMXKLdRjBlfQFkgWsoOMGrw==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/nextjs-sitemap-generator/-/nextjs-sitemap-generator-1.3.1.tgz",
+      "integrity": "sha512-QH4EDS17L8h7IHD3D7tW7+eDX9qLJloDaBPOM+t3R1nsM7xofI4EXwXgboB9EbEp0be5YYU3MHKxg/9guiEcKw==",
       "dev": true,
       "dependencies": {
         "date-fns": "^2.9.0"
@@ -24676,9 +24676,9 @@
       "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
     },
     "nextjs-sitemap-generator": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/nextjs-sitemap-generator/-/nextjs-sitemap-generator-1.1.3.tgz",
-      "integrity": "sha512-CNZ9pN4FNsXvkhtU7o2yPkyxEIsjwWJxGNLTDYApRJhdtZ0FfZzPleRHFCJPdbtiMXKLdRjBlfQFkgWsoOMGrw==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/nextjs-sitemap-generator/-/nextjs-sitemap-generator-1.3.1.tgz",
+      "integrity": "sha512-QH4EDS17L8h7IHD3D7tW7+eDX9qLJloDaBPOM+t3R1nsM7xofI4EXwXgboB9EbEp0be5YYU3MHKxg/9guiEcKw==",
       "dev": true,
       "requires": {
         "date-fns": "^2.9.0"

--- a/package.json
+++ b/package.json
@@ -35,6 +35,6 @@
     "eslint-config-codesupport": "^1.0.2",
     "eslint-plugin-react": "^7.20.3",
     "jest": "^26.6.3",
-    "nextjs-sitemap-generator": "^1.1.1"
+    "nextjs-sitemap-generator": "^1.3.1"
   }
 }

--- a/src/components/molecules/Navigation.js
+++ b/src/components/molecules/Navigation.js
@@ -16,6 +16,7 @@ const NavList = styled("ul")`
 
 const Logo = styled("img")`
 	object-fit: contain;
+	cursor: pointer;
 	
 	&& {
 		height: 50px;


### PR DESCRIPTION
Resolves #55 

#### Overview
- Upgraded `nextjs-sitemap-generator` to `1.3.1`
- Excluded `404` and `article/[path]` from `sitemap.xml`

<img width="622" alt="image" src="https://user-images.githubusercontent.com/12111454/135893551-e51cd017-bb1d-4727-ae66-621117d56023.png">
