### PR TITLE
Remove Auth0 section from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,6 @@ This repository contains the frontend for the CodeSupport Website. The project i
 2. Start the React app with `npm run dev`
 3. Navigate to [http://localhost:3000](http://localhost:3000) in your browser
 
-### Auth0
-This project uses [Auth0](https://auth0.com) for authentication. You will need to create a development project and register a SPA against it for free on their website and provide the following environment variables up and running:
-- `NEXT_PUBLIC_AUTH_DOMAIN` - your Auth0 application's auth domain
-- `NEXT_PUBLIC_AUTH_CLIENT_ID` - your Auth0 application's client ID
-- `NEXT_PUBLIC_BASE_URL` - the base URL to your Next.js project (likely `http://localhost:3000`)
-- `NEXT_PUBLIC_AUTH_AUDIENCE_URL` - the base URL to the API (likely `http://localhost:8080`)
-
 ## Structure
 - All pages live inside `pages/`
 - All other components live inside `components/`


### PR DESCRIPTION
Auth0 is no longer used therefore making this part of the README useless.