### PR TITLE
Deploy to Firebase Hosting Preview Channels

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,6 +6,9 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    environment:
+      name: Production
+      url: https://codesupport.dev
     steps:
       - uses: actions/checkout@v1
       - name: Build source code

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,6 +27,9 @@ jobs:
           npm run test
   preview_deployment:
     runs-on: ubuntu-latest
+    environment:
+      name: Development
+      url: ${{ steps.firebase_hosting_deploy.outputs.details_url }}
     needs: [lint, build, test]
     steps:
       - uses: actions/checkout@v3
@@ -35,6 +38,7 @@ jobs:
           npm ci
           npm run export
       - uses: FirebaseExtended/action-hosting-deploy@v0
+        id: firebase_hosting_deploy
         with:
           firebaseServiceAccount: "${{ secrets.FIREBASE_SERVICE_ACCOUNT_CODESUPPORT_DEVELOPMENT }}"
           repoToken: "${{ secrets.GITHUB_ACTION }}"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,3 +25,18 @@ jobs:
         run: |
           npm ci
           npm run test
+  preview_deployment:
+    runs-on: ubuntu-latest
+    needs: [lint, build, test]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Prepare for Deployment
+        run: |
+          npm ci
+          npm run export
+      - uses: FirebaseExtended/action-hosting-deploy@v0
+        with:
+          firebaseServiceAccount: "${{ secrets.FIREBASE_SERVICE_ACCOUNT_CODESUPPORT_DEVELOPMENT }}"
+          repoToken: "${{ secrets.GITHUB_ACTION }}"
+          expires: 7d
+          projectId: codesupport-development


### PR DESCRIPTION
Deploy to preview branches so that reviewing PRs is easier and removes the need to clone forks locally.