### PR TITLE
Improve Article Font Weight Readability

### DIFF
--- a/src/components/molecules/Article.tsx
+++ b/src/components/molecules/Article.tsx
@@ -29,7 +29,7 @@ export default styled("article")`
 	.markdown-content{
 		p{
 			color: var(--article-body-text-color);
-			font-weight: 300;
+			font-weight: var(--article-body-font-weight);
 		}
 
 		blockquote{
@@ -53,7 +53,7 @@ export default styled("article")`
 		ul, ol{
 			li{
 				color: var(--article-body-text-color);
-				font-weight: 300;
+				font-weight: var(--article-body-font-weight);
 			}
 		}
 	}

--- a/src/pages/article/[path].tsx
+++ b/src/pages/article/[path].tsx
@@ -14,7 +14,7 @@ import {GetStaticPropsContext} from "next";
 
 const ArticleMeta = styled("p")`
 	color: var(--article-meta-text-color);
-	font-size: small;
+	font-size: calc(var(--body-font-size) * 0.85);
 	margin-bottom: calc(var(--spacer) * 2);
 	margin-top: calc(var(--spacer) / 4);
 `;

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -42,6 +42,7 @@
         Font controls for individual articles
     */
     --article-body-font-size: 1rem;
+    --article-body-font-weight: 400;
     --article-meta-text-color: hsl(205, 15%, 60%);
     --article-body-text-color: hsl(206deg 10.69% 35.7%);
 


### PR DESCRIPTION
In the recent front-end overhaul, I seem to have left the font-weight of article markdown rendered content as 300. On some monitors, this appeared fine; however, on many DPIs this font-weight is too thin for accessible reading.

This PR does the following changes:
- Creates a new CSS variable to control article font-weight
- Adjusts the font-weight of article content to 400 (a standard weight)
- Additionally, the `font-size: small` of the article meta content (author + date section) has been changed to a calculated font-size instead of using the "small" value

Before and after images below (image previews may be blurry, click them for the full size)

![image](https://github.com/codesupport/website-frontend/assets/17110935/6f7f0607-f677-440e-ab84-cb878822b69c)

![image](https://github.com/codesupport/website-frontend/assets/17110935/91df0f83-1b20-4a5b-8e19-6cc21738dcc6)
