### PR TITLE
Resolves Article Shared Button Text Alignment

### DIFF
--- a/src/components/molecules/ShareButtons.tsx
+++ b/src/components/molecules/ShareButtons.tsx
@@ -5,13 +5,19 @@ import {IconProp} from "@fortawesome/fontawesome-svg-core";
 
 const Wrapper = styled("div")`
 	max-width: 500px;
-	margin: 25px auto;
 	display: flex;
+	gap: calc(var(--spacer));
 	justify-content: space-evenly;
+	margin: calc(var(--spacer) * 1.5) auto;
+	padding: 0 calc(var(--spacer));
+	text-align: center;
 	
 	a {
-		margin: 0 12.5px;
 		line-height: 15px;
+	}
+
+	@media (max-width: 450px){
+		flex-direction: column;
 	}
 `;
 


### PR DESCRIPTION
Closes #136 

This PR addresses small-screen text alignment with the share buttons, but also modifies the existing CSS to use the variables brought in by the front-end overhaul for consistent spacing and gapping. 

The share buttons now look equivalent on large screens, but on smaller devices will align their text to the center but also stack vertically and use flex gapping for component spacing.

Current view on Galaxy Z Fold 5:

![image](https://github.com/codesupport/website-frontend/assets/17110935/fae9cc1d-a91a-46a0-a2bb-631cd9fecfc8)

New view:

![image](https://github.com/codesupport/website-frontend/assets/17110935/e9d96e10-599d-4b30-9406-4de8d1684a8a)

